### PR TITLE
feature: find all references

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,5 +34,10 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Run e2e tests
-        run: npm run test:e2e
         if: runner.os != 'Linux'
+        uses: nick-fields/retry@e88a9994b039653512d697de1bce46b00bfe11b5
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: npm run test:e2e
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,16 @@
 {
-  "somesass.scannerDepth": 30,
-  "somesass.scannerExclude": [
-    "**/.git",
-    "**/node_modules",
-    "**/bower_components"
-  ],
-  "somesass.scanImportedFiles":  true,
-  "somesass.showErrors": false,
-  "somesass.suggestAllFromOpenDocument": false,
-  "somesass.suggestFromUseOnly": false,
-  "somesass.suggestVariables": true,
-  "somesass.suggestMixins": true,
-  "somesass.suggestFunctions": true,
-  "somesass.suggestFunctionsInStringContextAfterSymbols": " (+-*%"
+	"somesass.scannerDepth": 30,
+	"somesass.scannerExclude": [
+		"**/.git/**",
+		"**/node_modules/**",
+		"**/bower_components/**"
+	],
+	"somesass.scanImportedFiles":  true,
+	"somesass.showErrors": false,
+	"somesass.suggestAllFromOpenDocument": false,
+	"somesass.suggestFromUseOnly": false,
+	"somesass.suggestVariables": true,
+	"somesass.suggestMixins": true,
+	"somesass.suggestFunctions": true,
+	"somesass.suggestFunctionsInStringContextAfterSymbols": " (+-*%"
 }

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ could suggest a `hello()` function (`|` in this case indicates cursor position).
 
 #### Exclude files or folders
 
-List of [glob](https://github.com/mrmlnc/fast-glob) patterns for directories that are excluded when scanning.
+List of [micromatch](https://github.com/micromatch/micromatch) patterns for directories that are excluded when scanning.
 
 - JSON key: `somesass.scannerExclude`.
-- Default value: `["**/.git", "**/node_modules", "**/bower_components"]`.
+- Default value: `["**/.git/**", "**/node_modules/**", "**/bower_components/**"]`.
 
 #### Adjust scanner depth
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Supports standalone SCSS, as well as style blocks inside Vue and Svelte componen
 
 Based on SCSS Intellisense by [Denis Malinochkin and contributors](https://github.com/mrmlnc/vscode-scss). Uses the built-in VS Code language server for SCSS.
 
+Visit the [release section on GitHub](https://github.com/wkillerud/vscode-scss/releases) to see what has changed between versions.
+
 ## Setup
 
 Search for Some Sass (`SomewhatStationery.some-sass`) from the extension installer within VS Code or install from [the Marketplace](https://marketplace.visualstudio.com/items?itemName=SomewhatStationery.some-sass).
@@ -41,7 +43,9 @@ Documentation written with SassDoc will be included in the hover information. Ad
 
 ![](images/sassdoc-hover.gif)
 
-### Go to definition
+### Code navigation
+
+#### Go to Definition
 
 To use this feature, either:
 
@@ -54,6 +58,24 @@ To use this feature, either:
 To use this feature – in the `Go` menu – choose [Go to Symbol](https://code.visualstudio.com/Docs/editor/editingevolved#_go-to-symbol) either for Workspace (`Cmd + T`) or for Editor (`Cmd + Shift + O`).
 
 ![](images/workspace-symbols.gif)
+
+#### Go to References
+
+Shows an inline view of all references to the variable, mixin or function designed
+for quick navigation.
+
+To use this feature, either:
+
+- Right-click a variable, mixin or function and choose `Go to References`.
+- Place the cursor on the variable, moxin or function, open the `Go` menu and choose `Go to References`
+
+#### Find All References
+
+Opens a pane in your workbench with a list of all references to the variable,
+mixin or function.
+
+To use this feature, right-click a variable, mixin or function and choose
+`Find All References`.
 
 ## Recommended settings for Visual Studio Code
 

--- a/fixtures/e2e/.vscode/settings.json
+++ b/fixtures/e2e/.vscode/settings.json
@@ -1,16 +1,16 @@
 {
-  "somesass.scannerDepth": 30,
-  "somesass.scannerExclude": [
-    "**/.git",
-    "**/node_modules",
-    "**/bower_components"
-  ],
-  "somesass.scanImportedFiles":  true,
-  "somesass.showErrors": false,
-  "somesass.suggestAllFromOpenDocument": false,
-  "somesass.suggestFromUseOnly": false,
-  "somesass.suggestVariables": true,
-  "somesass.suggestMixins": true,
-  "somesass.suggestFunctions": true,
-  "somesass.suggestFunctionsInStringContextAfterSymbols": " (+-*%"
+	"somesass.scannerDepth": 30,
+	"somesass.scannerExclude": [
+		"**/.git/**",
+		"**/node_modules/**",
+		"**/bower_components/**"
+	],
+	"somesass.scanImportedFiles":  true,
+	"somesass.showErrors": false,
+	"somesass.suggestAllFromOpenDocument": false,
+	"somesass.suggestFromUseOnly": false,
+	"somesass.suggestVariables": true,
+	"somesass.suggestMixins": true,
+	"somesass.suggestFunctions": true,
+	"somesass.suggestFunctionsInStringContextAfterSymbols": " (+-*%"
 }

--- a/fixtures/e2e/references/_dev.scss
+++ b/fixtures/e2e/references/_dev.scss
@@ -1,0 +1,1 @@
+@forward "fun" as fun-*;

--- a/fixtures/e2e/references/_fun.scss
+++ b/fixtures/e2e/references/_fun.scss
@@ -1,0 +1,6 @@
+@function hello($var) {
+	@return $var;
+}
+
+$name: "there";
+$reply: "general";

--- a/fixtures/e2e/references/_one.scss
+++ b/fixtures/e2e/references/_one.scss
@@ -1,0 +1,6 @@
+@use "dev";
+
+.a {
+	// Here it comes!
+	content: dev.fun-hello(dev.$fun-name);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "some-sass",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "some-sass",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"license": "MIT",
 			"dependencies": {
 				"color": "4.2.3",
@@ -25,6 +25,7 @@
 				"@nodelib/fs.macchiato": "1.0.4",
 				"@types/color": "3.0.3",
 				"@types/color-name": "1.1.1",
+				"@types/micromatch": "^2.3.31",
 				"@types/mocha": "9.1.1",
 				"@types/node": "16.11.43",
 				"@types/sinon": "10.0.12",
@@ -848,6 +849,15 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
+		"node_modules/@types/micromatch": {
+			"version": "2.3.31",
+			"resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-2.3.31.tgz",
+			"integrity": "sha512-17WSoNz/GKLSfcomM8cMoJJQG2cDKvsoDFTtbwjEMxcizGb0HT6EBRi8qR7NW+XSaVdxHzq/WV/TUOm5f/ksag==",
+			"dev": true,
+			"dependencies": {
+				"@types/parse-glob": "*"
+			}
+		},
 		"node_modules/@types/mocha": {
 			"version": "9.1.1",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
@@ -864,6 +874,12 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+			"dev": true
+		},
+		"node_modules/@types/parse-glob": {
+			"version": "3.0.29",
+			"resolved": "https://registry.npmjs.org/@types/parse-glob/-/parse-glob-3.0.29.tgz",
+			"integrity": "sha512-OFwMPH5eJOhtwR92GMjTNWukaKTdWQC12cBgRvrTQl5CwhruSq6734wi1CTSh5Qjm/pMJWaKOOPKZOp6FpIkXQ==",
 			"dev": true
 		},
 		"node_modules/@types/sinon": {
@@ -5767,9 +5783,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.0.tgz",
-			"integrity": "sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==",
+			"version": "5.14.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -7082,6 +7098,15 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
+		"@types/micromatch": {
+			"version": "2.3.31",
+			"resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-2.3.31.tgz",
+			"integrity": "sha512-17WSoNz/GKLSfcomM8cMoJJQG2cDKvsoDFTtbwjEMxcizGb0HT6EBRi8qR7NW+XSaVdxHzq/WV/TUOm5f/ksag==",
+			"dev": true,
+			"requires": {
+				"@types/parse-glob": "*"
+			}
+		},
 		"@types/mocha": {
 			"version": "9.1.1",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
@@ -7098,6 +7123,12 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+			"dev": true
+		},
+		"@types/parse-glob": {
+			"version": "3.0.29",
+			"resolved": "https://registry.npmjs.org/@types/parse-glob/-/parse-glob-3.0.29.tgz",
+			"integrity": "sha512-OFwMPH5eJOhtwR92GMjTNWukaKTdWQC12cBgRvrTQl5CwhruSq6734wi1CTSh5Qjm/pMJWaKOOPKZOp6FpIkXQ==",
 			"dev": true
 		},
 		"@types/sinon": {
@@ -10789,9 +10820,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.0.tgz",
-			"integrity": "sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==",
+			"version": "5.14.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
 						"type": "string"
 					},
 					"default": [
-						"**/.git",
-						"**/node_modules",
-						"**/bower_components"
+						"**/.git/**",
+						"**/node_modules/**",
+						"**/bower_components/**"
 					],
 					"description": "List of glob patterns for directories that are excluded when scanning."
 				},
@@ -97,6 +97,7 @@
 		"@nodelib/fs.macchiato": "1.0.4",
 		"@types/color": "3.0.3",
 		"@types/color-name": "1.1.1",
+		"@types/micromatch": "^2.3.31",
 		"@types/mocha": "9.1.1",
 		"@types/node": "16.11.43",
 		"@types/sinon": "10.0.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "some-sass",
 	"displayName": "Some Sass",
 	"description": "Provides code suggestions, documentation and code navigation for modern SCSS",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"publisher": "SomewhatStationery",
 	"license": "MIT",
 	"engines": {

--- a/src/unsafe/providers/completion/completion.ts
+++ b/src/unsafe/providers/completion/completion.ts
@@ -375,12 +375,6 @@ function createMixinCompletionItems(
 			};
 		}
 
-		// Not all mixins have @content, but when they do, be smart about adding brackets
-		// and move the cursor to be ready to add said contents.
-		if (mixin.sassdoc?.content) {
-			insertText += " {\n\t$0\n}"
-		}
-
 		const detail = `Mixin declared in ${scssDocument.fileName}`;
 
 		completions.push({
@@ -398,6 +392,29 @@ function createMixinCompletionItems(
 				value: documentation,
 			}
 		});
+
+		// Not all mixins have @content, but when they do, be smart about adding brackets
+		// and move the cursor to be ready to add said contents.
+		// Include as separate suggestion since content may not always be needed or wanted.
+		if (mixin.sassdoc?.content) {
+			const details = { ...labelDetails };
+			details.detail = details.detail ? details.detail + ' { }' : ' { }';
+			completions.push({
+				label,
+				labelDetails: details,
+				filterText,
+				sortText,
+				kind: CompletionItemKind.Snippet,
+				detail,
+				insertTextFormat: InsertTextFormat.Snippet,
+				insertText: insertText += " {\n\t$0\n}",
+				tags: Boolean(mixin.sassdoc?.deprecated) ? [CompletionItemTag.Deprecated] : [],
+				documentation: {
+					kind: MarkupKind.Markdown,
+					value: documentation,
+				}
+			});
+		}
 	}
 
 	return completions;

--- a/src/unsafe/providers/hover.ts
+++ b/src/unsafe/providers/hover.ts
@@ -208,16 +208,22 @@ export function doHover(document: TextDocument, offset: number, storage: Storage
 	for (const { reference, exports } of Object.values(sassBuiltInModules)) {
 		for (const [name, { description }] of Object.entries(exports)) {
 			if (name === identifier.name) {
-				return {
-					contents: {
-						kind: MarkupKind.Markdown,
-						value: [
-							description,
-							'',
-							`[Sass reference](${reference}#${name})`,
-						].join('\n')
-					},
-				};
+				// Make sure we're not just hovering over a CSS function.
+				// Confirm we are looking at something that is the child of a module.
+				const isModule = hoverNode.getParent().type === NodeType.Module ||
+					hoverNode.getParent().getParent().type === NodeType.Module;
+				if (isModule) {
+					return {
+						contents: {
+							kind: MarkupKind.Markdown,
+							value: [
+								description,
+								'',
+								`[Sass reference](${reference}#${name})`,
+							].join('\n')
+						},
+					};
+				}
 			}
 		}
 	}

--- a/src/unsafe/providers/hover.ts
+++ b/src/unsafe/providers/hover.ts
@@ -12,6 +12,7 @@ import { asDollarlessVariable, getLimitedString } from '../utils/string';
 import { applySassDoc } from '../utils/sassdoc';
 import { sassDocAnnotations } from '../sassdocAnnotations';
 import { sassBuiltInModules } from '../sassBuiltInModules';
+import type { Token } from '../types/tokens';
 
 type Identifier = { kind: SymbolKind; name: string };
 
@@ -137,7 +138,6 @@ export function doHover(document: TextDocument, offset: number, storage: Storage
 		// Tokenize the document and look for the closest non-space token to offset.
 		// If it's a comment, look for SassDoc annotations under the cursor.
 
-		type Token = [string, string, number | undefined];
 		const tokens: Array<Token> = tokenizer(document.getText());
 
 		let hoverToken: Token | null = null;

--- a/src/unsafe/providers/references/index.ts
+++ b/src/unsafe/providers/references/index.ts
@@ -1,0 +1,1 @@
+export { provideReferences } from './references';

--- a/src/unsafe/providers/references/references.ts
+++ b/src/unsafe/providers/references/references.ts
@@ -1,0 +1,245 @@
+'use strict';
+
+import { tokenizer } from 'scss-symbols-parser';
+import { Location, Position, Range, ReferenceContext, SymbolKind } from 'vscode-languageserver-types';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
+
+import type StorageService from '../../services/storage';
+import { getDefinitionSymbol } from '../goDefinition';
+import type { IScssDocument, ScssSymbol } from '../../types/symbols';
+import type { Token } from '../../types/tokens';
+import { asDollarlessVariable, stripTrailingComma, stripParentheses } from '../../utils/string';
+import { INode, NodeType } from '../../types/nodes';
+
+export async function provideReferences(document: TextDocument, offset: number, storage: StorageService, context: ReferenceContext): Promise<Location[] | null> {
+	const scssDocument = storage.get(document.uri);
+	if (!scssDocument) {
+		return null;
+	}
+
+	const referenceNode = scssDocument.getNodeAt(offset);
+	if (!referenceNode || !referenceNode.type) {
+		return null;
+	}
+
+	const referenceIdentifier = getIdentifier(document, referenceNode, context);
+	if (!referenceIdentifier) {
+		return null;
+	}
+
+	let definitionSymbol: ScssSymbol | null = null;
+	let definitionDocument: IScssDocument | null = null;
+
+	// Check to see if the current document is the one declaring the symbol before we go looking through the project
+	for (const symbol of scssDocument.getSymbols()) {
+		const symbolName = asDollarlessVariable(symbol.name);
+		const identifierName = asDollarlessVariable(referenceIdentifier.name);
+		if (symbolName === identifierName && symbol.kind === referenceIdentifier.kind) {
+			definitionSymbol = symbol;
+			definitionDocument = scssDocument;
+		}
+	}
+
+	if (!definitionSymbol || !definitionDocument) {
+		[definitionSymbol, definitionDocument] = getDefinitionSymbol(document, storage, referenceIdentifier);
+	}
+
+	if (!definitionSymbol || !definitionDocument) {
+		return null;
+	}
+
+	const references: Location[] = [];
+
+	for (const scssDocument of storage.values()) {
+		const text = scssDocument.getText();
+		const tokens: Token[] = tokenizer(text);
+
+		for (const [tokenType, text, offset] of tokens) {
+			if (tokenType !== 'word' && tokenType !== 'brackets') {
+				continue;
+			}
+
+			// Tokens from maps include their trailing comma.
+			// Tokens of function parameters include the function parentheses.
+			// Strip them before comparing.
+			const trailingCommalessText = stripTrailingComma(text);
+			const parentheseslessText = stripParentheses(text);
+			const dollarlessDefinition = stripTrailingComma(asDollarlessVariable(definitionSymbol.name));
+
+			const isWordMatch = tokenType === 'word' && trailingCommalessText.endsWith(dollarlessDefinition);
+			const isParameterMatch = tokenType === 'brackets' && text.includes(dollarlessDefinition);
+			if (isWordMatch || isParameterMatch) {
+				// For type 'word' offset should always be defined, but default to 0 just in case
+				let adjustedOffset = offset || 0;
+				let adjustedText = isParameterMatch ? parentheseslessText : trailingCommalessText;
+
+				// The tokenizer treats the namespace and variable name as a single word.
+				// We need the offset for the actual variable, so find its position in the word.
+				if (trailingCommalessText !== referenceIdentifier.name) {
+					adjustedText = adjustedText.split('.')[1] || adjustedText;
+					adjustedOffset = adjustedOffset + text.indexOf(adjustedText);
+				}
+
+				// Make sure we use the correct one.
+				// We do this in case the same identifier name is used in more than one namespace.
+				// foo.$var is not the same as bar.$var.
+				const definition = getDefinition(scssDocument, adjustedOffset, storage, context);
+				if (!definition) {
+					continue;
+				}
+
+				// If the files and position matches between the definition of the current token
+				// and the definition we found to begin with, we have a reference to report.
+				const isSameFile = await isSameRealPath(definition.uri, definitionDocument, storage);
+				if (isSameFile && isSamePosition(definitionSymbol.position, definition.range.start)) {
+					const start = scssDocument.positionAt(adjustedOffset);
+					const end = scssDocument.positionAt(adjustedOffset + adjustedText.length);
+					const range = Range.create(start, end);
+					const location = Location.create(scssDocument.uri, range);
+					references.push(location);
+				}
+			}
+		}
+	}
+
+	return references;
+}
+
+
+interface Identifier {
+	kind: SymbolKind;
+	position: Position;
+	name: string;
+}
+
+function getIdentifier(document: TextDocument, hoverNode: INode, context: ReferenceContext): Identifier | null {
+	let identifier: Identifier | null = null;
+
+	if (hoverNode.type === NodeType.VariableName) {
+		if (!context.includeDeclaration) {
+			const parent = hoverNode.getParent();
+			if (parent.type === NodeType.VariableDeclaration) {
+				return null;
+			}
+		}
+
+		identifier = {
+			name: hoverNode.getName(),
+			position: document.positionAt(hoverNode.offset),
+			kind: SymbolKind.Variable,
+		};
+	} else if (hoverNode.type === NodeType.Identifier) {
+		let i = 0;
+		let node = hoverNode;
+		let isMixin = false;
+		let isFunction = false;
+
+		while (!isMixin && !isFunction && i !== 2) {
+			node = node.getParent();
+
+			isMixin = node.type === NodeType.MixinReference;
+			isFunction = node.type === NodeType.Function;
+
+			if (context.includeDeclaration) {
+				isMixin = isMixin || node.type === NodeType.MixinDeclaration;
+				isFunction = isFunction || node.type === NodeType.FunctionDeclaration;
+			}
+
+			i++;
+		}
+
+		if (node && (isMixin || isFunction)) {
+			let kind: SymbolKind = SymbolKind.Method;
+
+			if (isFunction) {
+				kind = SymbolKind.Function;
+			}
+
+			identifier = {
+				name: node.getName(),
+				position: document.positionAt(node.offset),
+				kind
+			};
+		}
+	}
+
+	if (!identifier) {
+		return null;
+	}
+
+	return identifier;
+}
+
+function getDefinition(scssDocument: IScssDocument, offset: number, storage: StorageService, context: ReferenceContext): Location | null {
+	const definitionNode = scssDocument.getNodeAt(offset);
+	if (!definitionNode || !definitionNode.type) {
+		return null;
+	}
+	const definitionIdentifier = getIdentifier(scssDocument, definitionNode, context);
+	if (!definitionIdentifier) {
+		return null;
+	}
+	const [definitionSymbol, definitionDocument] = getDefinitionSymbol(scssDocument, storage, definitionIdentifier);
+	if (!definitionSymbol || !definitionDocument) {
+		return null;
+	}
+
+	const definitionSymbolLocation = Location.create(definitionDocument.uri, {
+		start: definitionSymbol.position,
+		end: {
+			line: definitionSymbol.position.line,
+			character: definitionSymbol.position.character + definitionSymbol.name.length
+		}
+	});
+
+	return definitionSymbolLocation;
+}
+
+/**
+ * In certain workpaces, like monorepos, you may have a local file symlinked
+ * and referenced via node_modules. In those cases we want to compare the
+ * original non-symlinked files on disk. If the filename is the same, try
+ * to look up the _real_ path and compare that.
+ *
+ * @param link
+ * @param referenced
+ * @returns
+ */
+async function isSameRealPath(link: string, referenced: IScssDocument, storage: StorageService): Promise<boolean> {
+	if (!link) {
+		return false;
+	}
+
+	// Checking the file system is expensive, so do the optimistic thing first.
+	// If the URIs match, we're good.
+	if (link === referenced.uri) {
+		return true;
+	} else if (link.includes(referenced.fileName)) {
+		try {
+			const linkedDocument = storage.get(link);
+			if (!linkedDocument) {
+				return false;
+			}
+			const realLinkFsPath = await linkedDocument.getRealPath();
+			if (!realLinkFsPath) {
+				return false;
+			}
+			const realReferencedPath = await referenced.getRealPath();
+			if (!realReferencedPath) {
+				return false;
+			}
+
+			if (realLinkFsPath === realReferencedPath) {
+				return true;
+			}
+		} catch (e) {
+			// Guess it really doesn't exist
+		}
+	}
+
+	return false;
+}
+
+function isSamePosition(a: Position, b: Position): boolean {
+	return a.character === b.character && a.line === b.line;
+}

--- a/src/unsafe/providers/signatureHelp.ts
+++ b/src/unsafe/providers/signatureHelp.ts
@@ -175,6 +175,16 @@ export async function doSignatureHelp(
 		for (const { reference, exports } of Object.values(sassBuiltInModules)) {
 			for (const [name, { signature, description }] of Object.entries(exports)) {
 				if (name === entry.name) {
+					// Make sure we don't accidentaly match with CSS functions by checking
+					// for hints of a module name before the entry. Essentially look for ".".
+					// We could look for the module names, but that may be aliased away.
+					// Do an includes-check in case signature har more than one parameter.
+					const isNamespaced = textBeforeWord.includes(`.${name}(`);
+					if (!isNamespaced) {
+						continue;
+					}
+
+
 					const signatureInfo = SignatureInformation.create(`${name} ${signature}`);
 
 					signatureInfo.documentation = {

--- a/src/unsafe/services/scanner.ts
+++ b/src/unsafe/services/scanner.ts
@@ -70,7 +70,11 @@ export default class ScannerService {
 					continue;
 				}
 
-				await this.parse(URI.parse(symbol.link.target).fsPath, workspaceRoot, depth + 1);
+				try {
+					await this.parse(URI.parse(symbol.link.target).fsPath, workspaceRoot, depth + 1);
+				} catch (e) {
+					console.error((e as Error)?.message);
+				}
 			}
 		} catch (e) {
 			console.error((e as Error)?.message);

--- a/src/unsafe/test/providers/goDefinition.spec.ts
+++ b/src/unsafe/test/providers/goDefinition.spec.ts
@@ -19,10 +19,10 @@ storage.set('one.scss', new ScssDocument(
 			[["$a", { name: '$a', kind: SymbolKind.Variable, value: '1', offset: 0, position: { line: 1, character: 1 } }]]
 		),
 		mixins: new Map(
-			[["mixin", { name: 'mixin',kind: SymbolKind.Method, parameters: [], offset: 0, position: { line: 1, character: 1 } } ]]
+			[["mixin", { name: 'mixin', kind: SymbolKind.Method, parameters: [], offset: 0, position: { line: 1, character: 1 } }]]
 		),
 		functions: new Map(
-			[["make", { name: 'make', kind: SymbolKind.Function, parameters: [], offset: 0, position: { line: 1, character: 1 } } ]]
+			[["make", { name: 'make', kind: SymbolKind.Function, parameters: [], offset: 0, position: { line: 1, character: 1 } }]]
 		),
 		imports: new Map(),
 		uses: new Map(),
@@ -34,7 +34,7 @@ describe('Providers/GoDefinition', () => {
 	it('doGoDefinition - Variables', async () => {
 		const document = await helpers.makeDocument(storage, '.a { content: $a; }');
 
-		const actual = await goDefinition(document, 15, storage);
+		const actual = goDefinition(document, 15, storage);
 
 		assert.ok(actual);
 		assert.strictEqual(actual?.uri, './one.scss');
@@ -47,7 +47,7 @@ describe('Providers/GoDefinition', () => {
 	it('doGoDefinition - Variable definition', async () => {
 		const document = await helpers.makeDocument(storage, '$a: 1;');
 
-		const actual = await goDefinition(document, 2, storage);
+		const actual = goDefinition(document, 2, storage);
 
 		assert.strictEqual(actual, null);
 	});
@@ -55,7 +55,7 @@ describe('Providers/GoDefinition', () => {
 	it('doGoDefinition - Mixins', async () => {
 		const document = await helpers.makeDocument(storage, '.a { @include mixin(); }');
 
-		const actual = await goDefinition(document, 16, storage);
+		const actual = goDefinition(document, 16, storage);
 
 		assert.ok(actual);
 		assert.strictEqual(actual?.uri, './one.scss');
@@ -68,7 +68,7 @@ describe('Providers/GoDefinition', () => {
 	it('doGoDefinition - Mixin definition', async () => {
 		const document = await helpers.makeDocument(storage, '@mixin mixin($a) {}');
 
-		const actual = await goDefinition(document, 8, storage);
+		const actual = goDefinition(document, 8, storage);
 
 		assert.strictEqual(actual, null);
 	});
@@ -76,7 +76,7 @@ describe('Providers/GoDefinition', () => {
 	it('doGoDefinition - Mixin Arguments', async () => {
 		const document = await helpers.makeDocument(storage, '@mixin mixin($a) {}');
 
-		const actual = await goDefinition(document, 10, storage);
+		const actual = goDefinition(document, 10, storage);
 
 		assert.strictEqual(actual, null);
 	});
@@ -84,7 +84,7 @@ describe('Providers/GoDefinition', () => {
 	it('doGoDefinition - Functions', async () => {
 		const document = await helpers.makeDocument(storage, '.a { content: make(1); }');
 
-		const actual = await goDefinition(document, 16, storage);
+		const actual = goDefinition(document, 16, storage);
 
 		assert.ok(actual);
 		assert.strictEqual(actual?.uri, './one.scss');
@@ -97,7 +97,7 @@ describe('Providers/GoDefinition', () => {
 	it('doGoDefinition - Function definition', async () => {
 		const document = await helpers.makeDocument(storage, '@function make($a) {}');
 
-		const actual = await goDefinition(document, 8, storage);
+		const actual = goDefinition(document, 8, storage);
 
 		assert.strictEqual(actual, null);
 	});
@@ -105,7 +105,7 @@ describe('Providers/GoDefinition', () => {
 	it('doGoDefinition - Function Arguments', async () => {
 		const document = await helpers.makeDocument(storage, '@function make($a) {}');
 
-		const actual = await goDefinition(document, 13, storage);
+		const actual = goDefinition(document, 13, storage);
 
 		assert.strictEqual(actual, null);
 	});

--- a/src/unsafe/test/providers/references.spec.ts
+++ b/src/unsafe/test/providers/references.spec.ts
@@ -1,0 +1,592 @@
+'use strict';
+
+import assert from 'assert';
+import fs, { Stats } from 'fs';
+import sinon from 'sinon';
+
+import StorageService from '../../services/storage';
+import { provideReferences } from '../../providers/references';
+import * as fsUtils from '../../utils/fs';
+import * as helpers from '../helpers';
+
+
+describe('Providers/References', () => {
+	let statStub: sinon.SinonStub;
+	let fileExistsStub: sinon.SinonStub;
+	let storage: StorageService;
+
+	beforeEach(() => {
+		storage = new StorageService();
+		fileExistsStub = sinon.stub(fsUtils, 'fileExists').resolves(true);
+		statStub = sinon.stub(fs, 'stat').yields(null, new Stats());
+	});
+
+	afterEach(() => {
+		fileExistsStub.restore();
+		statStub.restore();
+	});
+
+	it('provideReferences - Variables', async () => {
+		await helpers.makeDocument(storage, '$day: "monday";', {
+			uri: 'ki.scss',
+		});
+
+		const firstUsage = await helpers.makeDocument(storage, [
+			'@use "ki";',
+			'',
+			'.a::after {',
+			' content: ki.$day;',
+			'}',
+		], {
+			uri: 'helen.scss',
+		});
+
+		await helpers.makeDocument(storage, [
+			'@use "ki";',
+			'',
+			'.a::before {',
+			' // Here it comes!',
+			' content: ki.$day;',
+			'}',
+		], {
+			uri: 'gato.scss',
+		});
+
+		const actual = await provideReferences(firstUsage, 38, storage, { includeDeclaration: true });
+
+		assert.ok(actual, 'provideReferences returned null for a variable');
+		assert.strictEqual(actual?.length, 3, 'Expected three references to $day: two usage and one declaration');
+
+		const [ki, helen, gato] = actual;
+
+		assert.ok(ki?.uri.endsWith('ki.scss'));
+		assert.deepStrictEqual(ki?.range, {
+			start: {
+				line: 0,
+				character: 0,
+			},
+			end: {
+				line: 0,
+				character: 4,
+			},
+		});
+
+		assert.ok(helen?.uri.endsWith('helen.scss'));
+		assert.deepStrictEqual(helen?.range, {
+			start: {
+				line: 3,
+				character: 13,
+			},
+			end: {
+				line: 3,
+				character: 17,
+			},
+		});
+
+		assert.ok(gato?.uri.endsWith('gato.scss'));
+		assert.deepStrictEqual(gato?.range, {
+			start: {
+				line: 4,
+				character: 13,
+			},
+			end: {
+				line: 4,
+				character: 17,
+			},
+		});
+	});
+
+	it('provideReferences - @forward variable with prefix', async () => {
+		await helpers.makeDocument(storage, '$day: "monday";', {
+			uri: 'ki.scss',
+		});
+
+		await helpers.makeDocument(storage, '@forward "ki" as ki-*;', {
+			uri: 'dev.scss',
+		});
+
+		const firstUsage = await helpers.makeDocument(storage, [
+			'@use "dev";',
+			'',
+			'.a::after {',
+			' content: dev.$ki-day;',
+			'}',
+		], {
+			uri: 'coast.scss',
+		});
+
+		await helpers.makeDocument(storage, [
+			'@use "ki";',
+			'',
+			'.a::before {',
+			' // Here it comes!',
+			' content: ki.$day;',
+			'}',
+		], {
+			uri: 'winter.scss',
+		});
+
+		const actual = await provideReferences(firstUsage, 42, storage, { includeDeclaration: true });
+
+		assert.ok(actual, 'provideReferences returned null for a prefixed variable');
+		assert.strictEqual(actual?.length, 3, 'Expected three references to $day: one prefixed usage and one not, plus the declaration');
+
+		const [ki, coast, winter] = actual;
+
+		assert.ok(ki?.uri.endsWith('ki.scss'));
+		assert.deepStrictEqual(ki?.range, {
+			start: {
+				line: 0,
+				character: 0,
+			},
+			end: {
+				line: 0,
+				character: 4,
+			},
+		});
+
+		assert.ok(coast?.uri.endsWith('coast.scss'));
+		assert.deepStrictEqual(coast?.range, {
+			start: {
+				line: 3,
+				character: 14,
+			},
+			end: {
+				line: 3,
+				character: 21,
+			},
+		});
+
+		assert.ok(winter?.uri.endsWith('winter.scss'));
+		assert.deepStrictEqual(winter?.range, {
+			start: {
+				line: 4,
+				character: 13,
+			},
+			end: {
+				line: 4,
+				character: 17,
+			},
+		});
+	});
+
+	it('provideReferences - Functions', async () => {
+		await helpers.makeDocument(storage, '@function hello() { @return 1; }', {
+			uri: 'func.scss',
+		});
+
+		const firstUsage = await helpers.makeDocument(storage, [
+			'@use "func";',
+			'',
+			'.a {',
+			' line-height: func.hello();',
+			'}',
+		], {
+			uri: 'one.scss',
+		});
+
+		await helpers.makeDocument(storage, [
+			'@use "func";',
+			'',
+			'.a {',
+			'	// Here it comes!',
+			' line-height: func.hello();',
+			'}',
+		], {
+			uri: 'two.scss',
+		});
+
+		const actual = await provideReferences(firstUsage, 42, storage, { includeDeclaration: true });
+
+		assert.ok(actual, 'provideReferences returned null for a function');
+		assert.strictEqual(actual?.length, 3, 'Expected three references to hello: two usages and one declaration');
+
+		const [func, one, two] = actual;
+
+		assert.ok(func?.uri.endsWith('func.scss'));
+		assert.deepStrictEqual(func?.range, {
+			start: {
+				line: 0,
+				character: 10,
+			},
+			end: {
+				line: 0,
+				character: 15,
+			},
+		});
+
+		assert.ok(one?.uri.endsWith('one.scss'));
+		assert.deepStrictEqual(one?.range, {
+			start: {
+				line: 3,
+				character: 19,
+			},
+			end: {
+				line: 3,
+				character: 24,
+			},
+		});
+
+		assert.ok(two?.uri.endsWith('two.scss'));
+		assert.deepStrictEqual(two?.range, {
+			start: {
+				line: 4,
+				character: 19,
+			},
+			end: {
+				line: 4,
+				character: 24,
+			},
+		});
+	});
+
+	it('provideReferences - @forward function with prefix', async () => {
+		await helpers.makeDocument(storage, '@function hello() { @return 1; }', {
+			uri: 'func.scss',
+		});
+
+		await helpers.makeDocument(storage, '@forward "func" as fun-*;', {
+			uri: 'dev.scss',
+		});
+
+		const firstUsage = await helpers.makeDocument(storage, [
+			'@use "dev";',
+			'',
+			'.a {',
+			' line-height: dev.fun-hello();',
+			'}',
+		], {
+			uri: 'one.scss',
+		});
+
+		await helpers.makeDocument(storage, [
+			'@use "func";',
+			'',
+			'.a {',
+			'	// Here it comes!',
+			' line-height: func.hello();',
+			'}',
+		], {
+			uri: 'two.scss',
+		});
+
+		const actual = await provideReferences(firstUsage, 40, storage, { includeDeclaration: true });
+
+		assert.ok(actual, 'provideReferences returned null for a prefixed function');
+		assert.strictEqual(actual?.length, 3, 'Expected three references to hello: one prefixed usage and one not, plus the declaration');
+
+		const [func, one, two] = actual;
+
+		assert.ok(func?.uri.endsWith('func.scss'));
+		assert.deepStrictEqual(func?.range, {
+			start: {
+				line: 0,
+				character: 10,
+			},
+			end: {
+				line: 0,
+				character: 15,
+			},
+		});
+
+		assert.ok(one?.uri.endsWith('one.scss'));
+		assert.deepStrictEqual(one?.range, {
+			start: {
+				line: 3,
+				character: 18,
+			},
+			end: {
+				line: 3,
+				character: 27,
+			},
+		});
+
+		assert.ok(two?.uri.endsWith('two.scss'));
+		assert.deepStrictEqual(two?.range, {
+			start: {
+				line: 4,
+				character: 19,
+			},
+			end: {
+				line: 4,
+				character: 24,
+			},
+		});
+	});
+
+	it('provideReferences - Mixins', async () => {
+		await helpers.makeDocument(storage, [
+			'@mixin hello() {',
+			'	line-height: 1;',
+			'}'
+		], {
+			uri: 'mix.scss',
+		});
+
+		const firstUsage = await helpers.makeDocument(storage, [
+			'@use "mix";',
+			'',
+			'.a {',
+			' @include mix.hello();',
+			'}',
+		], {
+			uri: 'one.scss',
+		});
+
+		await helpers.makeDocument(storage, [
+			'@use "mix";',
+			'',
+			'.a {',
+			'	// Here it comes!',
+			' @include mix.hello;',
+			'}',
+		], {
+			uri: 'two.scss',
+		});
+
+		const actual = await provideReferences(firstUsage, 33, storage, { includeDeclaration: true });
+
+		assert.ok(actual, 'provideReferences returned null for a mixin');
+		assert.strictEqual(actual?.length, 3, 'Expected three references to hello: two usages and one declaration');
+
+		const [mix, one, two] = actual;
+
+		assert.ok(mix?.uri.endsWith('mix.scss'));
+		assert.deepStrictEqual(mix?.range, {
+			start: {
+				line: 0,
+				character: 7,
+			},
+			end: {
+				line: 0,
+				character: 12,
+			},
+		});
+
+		assert.ok(one?.uri.endsWith('one.scss'));
+		assert.deepStrictEqual(one?.range, {
+			start: {
+				line: 3,
+				character: 14,
+			},
+			end: {
+				line: 3,
+				character: 19,
+			},
+		});
+
+		assert.ok(two?.uri.endsWith('two.scss'));
+		assert.deepStrictEqual(two?.range, {
+			start: {
+				line: 4,
+				character: 14,
+			},
+			end: {
+				line: 4,
+				character: 19,
+			},
+		});
+	});
+
+	it('provideReferences - @forward mixin with prefix', async () => {
+		await helpers.makeDocument(storage, [
+			'@mixin hello() {',
+			'	line-height: 1;',
+			'}'
+		], {
+			uri: 'mix.scss',
+		});
+
+		await helpers.makeDocument(storage, '@forward "mix" as mix-*;', {
+			uri: 'dev.scss',
+		});
+
+		const firstUsage = await helpers.makeDocument(storage, [
+			'@use "dev";',
+			'',
+			'.a {',
+			' @include dev.mix-hello();',
+			'}',
+		], {
+			uri: 'one.scss',
+		});
+
+		await helpers.makeDocument(storage, [
+			'@use "mix";',
+			'',
+			'.a {',
+			'	// Here it comes!',
+			' @include mix.hello();',
+			'}',
+		], {
+			uri: 'two.scss',
+		});
+
+		const actual = await provideReferences(firstUsage, 33, storage, { includeDeclaration: true });
+
+		assert.ok(actual, 'provideReferences returned null for a mixin');
+		assert.strictEqual(actual?.length, 3, 'Expected three references to hello: one prefixed usage and one not, plus the declaration');
+
+		const [mix, one, two] = actual;
+
+		assert.ok(mix?.uri.endsWith('mix.scss'));
+		assert.deepStrictEqual(mix?.range, {
+			start: {
+				line: 0,
+				character: 7,
+			},
+			end: {
+				line: 0,
+				character: 12,
+			},
+		});
+
+		assert.ok(one?.uri.endsWith('one.scss'));
+		assert.deepStrictEqual(one?.range, {
+			start: {
+				line: 3,
+				character: 14,
+			},
+			end: {
+				line: 3,
+				character: 23,
+			},
+		});
+
+		assert.ok(two?.uri.endsWith('two.scss'));
+		assert.deepStrictEqual(two?.range, {
+			start: {
+				line: 4,
+				character: 14,
+			},
+			end: {
+				line: 4,
+				character: 19,
+			},
+		});
+	});
+
+	it('providesReference - @forward function parameter with prefix', async () => {
+		await helpers.makeDocument(storage, [
+			'@function hello($var) { @return $var; }',
+			'$name: "there";',
+			'$reply: "general";',
+		], {
+			uri: 'fun.scss',
+		});
+
+		await helpers.makeDocument(storage, '@forward "fun" as fun-*;', {
+			uri: 'dev.scss',
+		});
+
+		const usage = await helpers.makeDocument(storage, [
+			'@use "dev";',
+			'',
+			'.a {',
+			'	// Here it comes!',
+			' content: dev.fun-hello(dev.$fun-name);',
+			'}',
+		], {
+			uri: 'one.scss',
+		});
+
+
+		const name = await provideReferences(usage, 66, storage, { includeDeclaration: true });
+		assert.ok(name, 'provideReferences returned null for a prefixed variable as a function parameter');
+		assert.strictEqual(name?.length, 2, 'Expected two references to $fun-name');
+
+		const [_, one] = name;
+
+		assert.ok(one?.uri.endsWith('one.scss'));
+		assert.deepStrictEqual(one?.range, {
+			start: {
+				line: 4,
+				character: 28,
+			},
+			end: {
+				line: 4,
+				character: 37,
+			},
+		});
+	});
+
+	it('providesReference - @forward in map with prefix', async () => {
+		await helpers.makeDocument(storage, [
+			'@function hello() { @return 1; }',
+			'$day: "monday";',
+		], {
+			uri: 'fun.scss',
+		});
+
+		await helpers.makeDocument(storage, '@forward "fun" as fun-*;', {
+			uri: 'dev.scss',
+		});
+
+		const usage = await helpers.makeDocument(storage, [
+			'@use "dev";',
+			'',
+			'$map: (',
+			' "gloomy": dev.$fun-day,',
+			' "goodbye": dev.fun-hello(),',
+			');',
+		], {
+			uri: 'one.scss',
+		});
+
+		const funDay = await provideReferences(usage, 36, storage, { includeDeclaration: true });
+
+		assert.ok(funDay, 'provideReferences returned null for a prefixed variable in a map');
+		assert.strictEqual(funDay?.length, 2, 'Expected two references to $day');
+
+		const [_, one] = funDay;
+
+		assert.ok(one?.uri.endsWith('one.scss'));
+		assert.deepStrictEqual(one?.range, {
+			start: {
+				line: 3,
+				character: 15,
+			},
+			end: {
+				line: 3,
+				character: 23,
+			},
+		});
+
+		const hello = await provideReferences(usage, 64, storage, { includeDeclaration: true });
+		assert.ok(hello, 'provideReferences returned null for a prefixed function in a map');
+		assert.strictEqual(hello?.length, 2, 'Expected two references to hello');
+	});
+
+	it('provideReferences - excludes declaration if context says so', async () => {
+		await helpers.makeDocument(storage, [
+			'@function hello() { @return 1; }',
+			'$day: "monday";',
+		], {
+			uri: 'fun.scss',
+		});
+
+		await helpers.makeDocument(storage, '@forward "fun" as fun-*;', {
+			uri: 'dev.scss',
+		});
+
+		const usage = await helpers.makeDocument(storage, [
+			'@use "dev";',
+			'',
+			'$map: (',
+			' "gloomy": dev.$fun-day,',
+			' "goodbye": dev.fun-hello(),',
+			');',
+		], {
+			uri: 'one.scss',
+		});
+
+		const funDay = await provideReferences(usage, 36, storage, { includeDeclaration: false });
+
+		assert.ok(funDay, 'provideReferences returned null for a variable excluding declarations');
+		assert.strictEqual(funDay?.length, 1, 'Expected one reference to $day');
+
+		const hello = await provideReferences(usage, 64, storage, { includeDeclaration: false });
+		assert.ok(hello, 'provideReferences returned null for a function excluding declarations');
+		assert.strictEqual(hello?.length, 1, 'Expected one reference to hello');
+	});
+});

--- a/src/unsafe/test/services/scanner.spec.ts
+++ b/src/unsafe/test/services/scanner.spec.ts
@@ -3,6 +3,7 @@
 import assert from 'assert';
 import path from 'path';
 import fs from 'fs';
+import { isMatch } from 'micromatch';
 
 import sinon from 'sinon';
 import { Stats } from '@nodelib/fs.macchiato';
@@ -79,8 +80,8 @@ describe('Services/Scanner', () => {
 			await scanner.scan([indexDocumentPath], workspaceRootUri);
 
 			const expected = new Map([
-					[indexDocumentUri, indexDocumentUri],
-					[variablesDocumentUri, variablesDocumentUri]
+				[indexDocumentUri, indexDocumentUri],
+				[variablesDocumentUri, variablesDocumentUri]
 			]);
 			assert.deepStrictEqual(storage.keys(), expected.keys());
 
@@ -110,6 +111,11 @@ describe('Services/Scanner', () => {
 
 			assert.strictEqual(fileExistsStub.callCount, 2, "File exists was not called twice");  // Scanner only calls once, but parser does as well
 			assert.strictEqual(readFileStub.callCount, 1, "Read file was not called once");
+		});
+
+		it('exclude matcher works as expected', () => {
+			assert.ok(isMatch('/home/user/project/.git/index', '**/.git/**'));
+			assert.ok(isMatch('/home/user/project/node_modules/package/some.scss', '**/node_modules/**'));
 		});
 	});
 });

--- a/src/unsafe/test/utils/string.spec.ts
+++ b/src/unsafe/test/utils/string.spec.ts
@@ -7,7 +7,8 @@ import {
 	getTextBeforePosition,
 	getTextAfterPosition,
 	getLimitedString,
-	asDollarlessVariable
+	asDollarlessVariable,
+	stripTrailingComma
 } from '../../utils/string';
 
 describe('Utils/String', () => {
@@ -44,4 +45,9 @@ describe('Utils/String', () => {
 		assert.strictEqual(asDollarlessVariable('$someText'), 'someText');
 		assert.strictEqual(asDollarlessVariable('$$$ (⌐■_■) $$$'), '$$ (⌐■_■) $$$');
 	});
+
+	it('stripTrailingComma', () => {
+		assert.strictEqual(stripTrailingComma('dev.$fun-day,'), 'dev.$fun-day');
+		assert.strictEqual(stripTrailingComma('dev.$fun-day'), 'dev.$fun-day');
+	})
 });

--- a/src/unsafe/types/symbols.ts
+++ b/src/unsafe/types/symbols.ts
@@ -22,7 +22,7 @@ export interface ScssMixin extends ScssSymbol {
 	parameters: Omit<ScssVariable, 'position' | 'kind'>[];
 }
 
-export interface ScssFunction extends ScssMixin {}
+export interface ScssFunction extends ScssMixin { }
 
 export interface ScssLink {
 	link: DocumentLink;
@@ -56,12 +56,15 @@ export interface IScssSymbols {
 export interface IScssDocument extends TextDocument, IScssSymbols {
 	textDocument: TextDocument;
 	ast: INode;
+	filePath: string;
 	/**
 	 * The last part of the URI, including extension.
 	 * For instance, given the URI `file:///home/test.scss`,
 	 * the fileName is `test.scss`.
 	 */
 	fileName: string;
+	/** Find and cache the real path (as opposed to symlinked) */
+	getRealPath: () => Promise<string | null>;
 	getLinks: (options?: { forwards: boolean }) => ScssLink[];
 	getSymbols: () => ScssSymbol[];
 	getNodeAt: (offset: number) => INode | null;

--- a/src/unsafe/types/tokens.ts
+++ b/src/unsafe/types/tokens.ts
@@ -1,0 +1,8 @@
+type TokenType = 'word' | 'comment' | 'at-word' | 'string' | ')' | '(' | 'brackets' | ';' | ':' | '}' | '{' | ']' | '[' | 'space';
+type TokenText = string;
+type TokenTextOffset = number;
+
+/**
+ * The result from the tokenizer function in scss-symbols-parser is an array of these Tokens.
+ */
+export type Token = [TokenType, TokenText, TokenTextOffset | undefined];

--- a/src/unsafe/utils/document.ts
+++ b/src/unsafe/utils/document.ts
@@ -24,8 +24,10 @@ export function getDocumentPath(currentPath: string, symbolsPath: string | undef
 	return docPath.replace(/\\/g, '/');
 }
 
+export const reNewline = /\r\n|\r|\n/;
+
 export function getLinesFromText(text: string): string[] {
-	return text.split(/\r\n|\r|\n/);
+	return text.split(reNewline);
 }
 
 /*---------------------------------------------------------------------------------------------
@@ -52,13 +54,13 @@ function resolvePathToModule(_moduleName: string, _relativeTo: string): string |
 }
 
 function resolve(from: string, to: string): string {
-  const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
-  if (resolvedUrl.protocol === 'resolve:') {
-    // `from` is a relative URL.
-    const { pathname, search, hash } = resolvedUrl;
-    return pathname + search + hash;
-  }
-  return resolvedUrl.toString();
+	const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+	if (resolvedUrl.protocol === 'resolve:') {
+		// `from` is a relative URL.
+		const { pathname, search, hash } = resolvedUrl;
+		return pathname + search + hash;
+	}
+	return resolvedUrl.toString();
 }
 
 export function buildDocumentContext(documentUri: string, workspaceRoot: URI): DocumentContext {

--- a/src/unsafe/utils/fs.ts
+++ b/src/unsafe/utils/fs.ts
@@ -39,3 +39,7 @@ export function readFile(filepath: string): Promise<string> {
 export function statFile(filepath: string): Promise<fs.Stats> {
 	return fs.promises.stat(filepath);
 }
+
+export async function realPath(symlink: string): Promise<string> {
+	return fs.promises.realpath(symlink);
+}

--- a/src/unsafe/utils/string.ts
+++ b/src/unsafe/utils/string.ts
@@ -53,3 +53,15 @@ export function getLimitedString(str: string, ellipsis = true): string {
 export function asDollarlessVariable(variable: string): string {
 	return variable.replace(/^\$/, '');
 }
+
+export function stripTrailingComma(string: string): string {
+	return stripTrailingCharacter(string, ",");
+}
+
+export function stripParentheses(string: string): string {
+	return string.replace(/[()]/g, '');
+}
+
+function stripTrailingCharacter(string: string, char: string): string {
+	return string.endsWith(char) ? string.substring(0, string.length - char.length) : string;
+}


### PR DESCRIPTION
## New features

- Find all references to variables, mixins and functions.
- Find all references to Sass built-in functions and variables.
- For mixins with `@content` SassDoc annotation, add and prefer a suggestion without brackets. The one with brackets now needs an Arrow Down keypress to use.

## Bugfixes

- Don't give signature help for CSS functions with the same name, for instance `scale()`.
- Don't give hover information for CSS functions with the same name, for instance `scale()`.
- Fix default exclude patterns so they work as expected when used with `micromatch`.