### PR TITLE
feat: resolve the base value behind variables

### DIFF
--- a/src/server/features/completion/completion.ts
+++ b/src/server/features/completion/completion.ts
@@ -115,6 +115,7 @@ export function doCompletion(
 		if (settings.suggestVariables && context.variable) {
 			const variables = createVariableCompletionItems(
 				scssDocument,
+				storage,
 				document,
 				context,
 			);
@@ -276,6 +277,7 @@ function traverseTree(
 		if (settings.suggestVariables && context.variable) {
 			const variables = createVariableCompletionItems(
 				scssDocument,
+				storage,
 				document,
 				context,
 				hiddenSymbols,

--- a/src/server/features/go-definition/go-definition.ts
+++ b/src/server/features/go-definition/go-definition.ts
@@ -33,6 +33,32 @@ export function goDefinition(
 	offset: number,
 	storage: StorageService,
 ): Location | null {
+	const result = getDefinition(document, offset, storage);
+	if (!result) {
+		return null;
+	}
+
+	const [definition, sourceDocument] = result;
+	if (!definition || !sourceDocument) {
+		return null;
+	}
+
+	const symbol = Location.create(sourceDocument.uri, {
+		start: definition.position,
+		end: {
+			line: definition.position.line,
+			character: definition.position.character + definition.name.length,
+		},
+	});
+
+	return symbol;
+}
+
+export function getDefinition(
+	document: TextDocument,
+	offset: number,
+	storage: StorageService,
+): [ScssSymbol, IScssDocument] | null {
 	const currentScssDocument = storage.get(document.uri);
 	if (!currentScssDocument) {
 		return null;
@@ -62,15 +88,7 @@ export function goDefinition(
 		return null;
 	}
 
-	const symbol = Location.create(sourceDocument.uri, {
-		start: definition.position,
-		end: {
-			line: definition.position.line,
-			character: definition.position.character + definition.name.length,
-		},
-	});
-
-	return symbol;
+	return [definition, sourceDocument];
 }
 
 function getIdentifier(

--- a/src/server/utils/scss.ts
+++ b/src/server/utils/scss.ts
@@ -1,0 +1,67 @@
+import { getDefinition } from "../features/go-definition";
+import { IScssDocument, NodeType, ScssVariable } from "../parser";
+import { getParentNodeByType } from "../parser/ast";
+import StorageService from "../storage";
+
+export function isReferencingVariable(variable: ScssVariable): boolean {
+	if (!variable.value) {
+		return false;
+	}
+	return variable.value.startsWith("$") || variable.value.includes(".$");
+}
+
+export function getBaseValueFrom(
+	variable: ScssVariable,
+	scssDocument: IScssDocument,
+	storage: StorageService,
+	depth = 0,
+): ScssVariable {
+	if (depth > 10) {
+		// Really?
+		return variable;
+	}
+
+	const node = scssDocument.getNodeAt(variable.offset);
+	if (!node) {
+		return variable;
+	}
+
+	const declaration = getParentNodeByType(node, NodeType.VariableDeclaration);
+	if (!declaration) {
+		return variable;
+	}
+
+	const value = declaration.getValue()?.getText();
+	if (!value) {
+		return variable;
+	}
+
+	const referenceOffset =
+		variable.offset + variable.name.length + value.indexOf("$") + 2;
+
+	const referenceNode = scssDocument.getNodeAt(referenceOffset);
+	if (!referenceNode) {
+		return variable;
+	}
+
+	const result = getDefinition(
+		scssDocument.textDocument,
+		referenceOffset,
+		storage,
+	);
+	if (!result) {
+		return variable;
+	}
+
+	const [definition, definitionDocument] = result;
+	if (isReferencingVariable(definition as ScssVariable)) {
+		return getBaseValueFrom(
+			definition as ScssVariable,
+			definitionDocument,
+			storage,
+			(depth += 1),
+		);
+	}
+
+	return definition as ScssVariable;
+}


### PR DESCRIPTION
For completions and hover info, try to look for the base value if a variable is just a reference to another variable.

For completions this for instance means you can get color previews for semantic names that reference foundation values.