### PR TITLE
chore: remove redundant custom settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,6 @@ There will unfortunately be duplicates.
 - JSON key: `somesass.suggestAllFromOpenDocument`
 - Default value: `false`.
 
-#### Control what types of symbols are suggested
-
-There are three settings that let you pick what types of symbols (variables, functions, mixins) should be suggested if you are only interested in some of them.
-By default, all of them are turned on.
-
-- JSON keys: `somesass.suggestFunctions`, `somesass.suggestMixins` and `somesass.suggestVariables`.
-- Default value: `true`.
-
 #### Decide when function suggestions should kick in
 
 Suggest functions after the specified symbols when in a string context.

--- a/package.json
+++ b/package.json
@@ -76,21 +76,6 @@
 					"default": false,
 					"description": "If your project uses the new module system with @use and @forward, you may want to only include suggestions from your used modules."
 				},
-				"somesass.suggestVariables": {
-					"type": "boolean",
-					"default": true,
-					"description": "Allows prompt Variables."
-				},
-				"somesass.suggestMixins": {
-					"type": "boolean",
-					"default": true,
-					"description": "Allows prompt Mixins."
-				},
-				"somesass.suggestFunctions": {
-					"type": "boolean",
-					"default": true,
-					"description": "Allows prompt Functions."
-				},
 				"somesass.suggestFunctionsInStringContextAfterSymbols": {
 					"type": "string",
 					"default": " (+-*%",

--- a/package.json
+++ b/package.json
@@ -59,12 +59,8 @@
 				"somesass.scanImportedFiles": {
 					"type": "boolean",
 					"default": true,
-					"description": "Allows scan imported files."
-				},
-				"somesass.showErrors": {
-					"type": "boolean",
-					"default": false,
-					"description": "Allows to display errors."
+					"deprecationMessage": "Will be removed at some point after `@import` becomes CSS-only.",
+					"description": "Allows scan imported files. Turning this off will severely limit functionality, and is not recommended."
 				},
 				"somesass.suggestAllFromOpenDocument": {
 					"type": "boolean",

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -88,15 +88,6 @@ export function createLanguageClientOptions(
 		suggestFromUseOnly:
 			configuration.get<boolean>("suggestFromUseOnly") ||
 			defaultSettings.suggestFromUseOnly,
-		suggestVariables:
-			configuration.get<boolean>("suggestVariables") ||
-			defaultSettings.suggestVariables,
-		suggestMixins:
-			configuration.get<boolean>("suggestMixins") ||
-			defaultSettings.suggestMixins,
-		suggestFunctions:
-			configuration.get<boolean>("suggestFunctions") ||
-			defaultSettings.suggestFunctions,
 		suggestFunctionsInStringContextAfterSymbols:
 			configuration.get<string>(
 				"suggestFunctionsInStringContextAfterSymbols",

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -80,8 +80,6 @@ export function createLanguageClientOptions(
 		scanImportedFiles:
 			configuration.get<boolean>("scanImportedFiles") ||
 			defaultSettings.scanImportedFiles,
-		showErrors:
-			configuration.get<boolean>("showErrors") || defaultSettings.showErrors,
 		suggestAllFromOpenDocument:
 			configuration.get<boolean>("suggestAllFromOpenDocument") ||
 			defaultSettings.suggestAllFromOpenDocument,

--- a/src/server/features/completion/completion.ts
+++ b/src/server/features/completion/completion.ts
@@ -112,7 +112,7 @@ export function doCompletion(
 			continue;
 		}
 
-		if (settings.suggestVariables && context.variable) {
+		if (context.variable) {
 			const variables = createVariableCompletionItems(
 				scssDocument,
 				storage,
@@ -122,7 +122,7 @@ export function doCompletion(
 			completions.items = completions.items.concat(variables);
 		}
 
-		if (settings.suggestMixins && context.mixin) {
+		if (context.mixin) {
 			const mixins = createMixinCompletionItems(
 				scssDocument,
 				document,
@@ -131,7 +131,7 @@ export function doCompletion(
 			completions.items = completions.items.concat(mixins);
 		}
 
-		if (settings.suggestFunctions && context.function) {
+		if (context.function) {
 			const functions = createFunctionCompletionItems(
 				scssDocument,
 				document,
@@ -274,7 +274,7 @@ function traverseTree(
 		settings.suggestAllFromOpenDocument ||
 		scssDocument.uri !== document.uri
 	) {
-		if (settings.suggestVariables && context.variable) {
+		if (context.variable) {
 			const variables = createVariableCompletionItems(
 				scssDocument,
 				storage,
@@ -286,7 +286,7 @@ function traverseTree(
 			completionItems = completionItems.concat(variables);
 		}
 
-		if (settings.suggestMixins && context.mixin) {
+		if (context.mixin) {
 			const mixins = createMixinCompletionItems(
 				scssDocument,
 				document,
@@ -297,7 +297,7 @@ function traverseTree(
 			completionItems = completionItems.concat(mixins);
 		}
 
-		if (settings.suggestFunctions && context.function) {
+		if (context.function) {
 			const functions = createFunctionCompletionItems(
 				scssDocument,
 				document,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -135,9 +135,7 @@ export class SomeSassServer {
 			try {
 				await scannerService.scan(files, workspaceRoot);
 			} catch (error) {
-				if (settings.showErrors) {
-					this.connection.window.showErrorMessage(String(error));
-				}
+				console.log(String(error));
 			}
 		});
 

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -10,9 +10,6 @@ export interface ISettings {
 	// Suggestions
 	readonly suggestAllFromOpenDocument: boolean;
 	readonly suggestFromUseOnly: boolean;
-	readonly suggestVariables: boolean;
-	readonly suggestMixins: boolean;
-	readonly suggestFunctions: boolean;
 	readonly suggestFunctionsInStringContextAfterSymbols: string;
 }
 
@@ -34,8 +31,5 @@ export const defaultSettings: ISettings = Object.freeze({
 	showErrors: false,
 	suggestAllFromOpenDocument: true,
 	suggestFromUseOnly: true,
-	suggestVariables: true,
-	suggestMixins: true,
-	suggestFunctions: true,
 	suggestFunctionsInStringContextAfterSymbols: " (+-*%",
 });

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -1,13 +1,7 @@
 export interface ISettings {
-	// Scanner
 	readonly scannerDepth: number;
 	readonly scannerExclude: string[];
 	readonly scanImportedFiles: boolean;
-
-	// Display
-	readonly showErrors: boolean;
-
-	// Suggestions
 	readonly suggestAllFromOpenDocument: boolean;
 	readonly suggestFromUseOnly: boolean;
 	readonly suggestFunctionsInStringContextAfterSymbols: string;
@@ -28,7 +22,6 @@ export const defaultSettings: ISettings = Object.freeze({
 		"**/bower_components/**",
 	],
 	scanImportedFiles: true,
-	showErrors: false,
 	suggestAllFromOpenDocument: true,
 	suggestFromUseOnly: true,
 	suggestFunctionsInStringContextAfterSymbols: " (+-*%",

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -68,9 +68,6 @@ export function makeSettings(options?: Partial<ISettings>): ISettings {
 		showErrors: false,
 		suggestAllFromOpenDocument: false,
 		suggestFromUseOnly: false,
-		suggestVariables: true,
-		suggestMixins: true,
-		suggestFunctions: true,
 		suggestFunctionsInStringContextAfterSymbols: " (+-*%",
 		...options,
 	};

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -65,7 +65,6 @@ export function makeSettings(options?: Partial<ISettings>): ISettings {
 		scannerDepth: 30,
 		scannerExclude: ["**/.git", "**/node_modules", "**/bower_components"],
 		scanImportedFiles: true,
-		showErrors: false,
 		suggestAllFromOpenDocument: false,
 		suggestFromUseOnly: false,
 		suggestFunctionsInStringContextAfterSymbols: " (+-*%",


### PR DESCRIPTION
VS Code has built-in settings for filtering out these things
(and more) on the front-end:

- `editor.suggest.showConstants`
- `editor.suggest.showFunctions`
- `editor.suggest.showMethods`
- `editor.suggest.showVariables`