### PR TITLE
fixes #61

### DIFF
--- a/server/src/features/completion/completion.ts
+++ b/server/src/features/completion/completion.ts
@@ -307,6 +307,11 @@ function traverseTree(
 
 		// Check to see if we have to go deeper
 		for (const child of leaf.getLinks()) {
+			// we don't go deeper if it's a nested @use
+			if ("isAliased" in child) {
+				return;
+			}
+
 			if (
 				!child.link.target ||
 				(child as ScssImport).dynamic ||


### PR DESCRIPTION
I've added a guard to prevent going deeper in the tree if we're on a @use in a @use.

For this, I check if the `isAliased` property (unique to `ScssUse` type and non optional) exists on a `use` link in the recursive part of the `traverseTree` function.

I've seen that the `// Check to see if we have to go deeper` comment appears also in these files:
- [diagnostics.ts](https://github.com/wkillerud/vscode-scss/blob/a2421b7e34397b79f27a2f5f0b3e5a57eeb9d296/server/src/features/diagnostics/diagnostics.ts#L169)
- [go-definition.ts](https://github.com/wkillerud/vscode-scss/blob/a2421b7e34397b79f27a2f5f0b3e5a57eeb9d296/server/src/features/go-definition/go-definition.ts#L265)
- [hover.ts](https://github.com/wkillerud/vscode-scss/blob/a2421b7e34397b79f27a2f5f0b3e5a57eeb9d296/server/src/features/hover/hover.ts#L396)
- [signature-help.ts](https://github.com/wkillerud/vscode-scss/blob/a2421b7e34397b79f27a2f5f0b3e5a57eeb9d296/server/src/features/signature-help/signature-help.ts#L337)

But I don't know what they're used for and I preferred not to touch them.