### PR TITLE
Don't follow more than the first use, and don't overwrite hover info with built-in

### DIFF
--- a/e2e/src/suite/hover/hover.test.ts
+++ b/e2e/src/suite/hover/hover.test.ts
@@ -3,12 +3,14 @@ import { testHover } from "./helper";
 
 describe("SCSS Hover Test", function () {
 	const docUri = getDocUri("hover/main.scss");
+	const collisionUri = getDocUri("hover/collision.scss");
 	const vueDocUri = getDocUri("hover/AppButton.vue");
 	const svelteDocUri = getDocUri("hover/AppButton.svelte");
 	const astroDocUri = getDocUri("hover/AppButton.astro");
 
 	before(async () => {
 		await showFile(docUri);
+		await showFile(collisionUri);
 		await showFile(vueDocUri);
 		await showFile(svelteDocUri);
 		await showFile(astroDocUri);
@@ -117,5 +119,14 @@ describe("SCSS Hover Test", function () {
 		};
 
 		await testHover(docUri, position(26, 22), expectedContents);
+	});
+
+	it("shows hover for user-defined symbol in case of naming collision with built-in", async () => {
+		// Prefixed symbols are shown with their original names
+		const expectedContents = {
+			contents: ["Deliberate name collision with sass:map"],
+		};
+
+		await testHover(collisionUri, position(5, 20), expectedContents);
 	});
 });

--- a/fixtures/e2e/completion/use-use/_first.scss
+++ b/fixtures/e2e/completion/use-use/_first.scss
@@ -1,0 +1,3 @@
+@use "./second";
+
+$first: second.$second;

--- a/fixtures/e2e/completion/use-use/_second.scss
+++ b/fixtures/e2e/completion/use-use/_second.scss
@@ -1,0 +1,1 @@
+$second: red;

--- a/fixtures/e2e/completion/use-use/main.scss
+++ b/fixtures/e2e/completion/use-use/main.scss
@@ -1,0 +1,3 @@
+@use "./first";
+
+$_hello: first.$;

--- a/fixtures/e2e/hover/_config.scss
+++ b/fixtures/e2e/hover/_config.scss
@@ -1,0 +1,4 @@
+/// Deliberate name collision with sass:map
+@function get() {
+  @return 1;
+}

--- a/fixtures/e2e/hover/collision.scss
+++ b/fixtures/e2e/hover/collision.scss
@@ -1,0 +1,6 @@
+@use "./config";
+@use "sass:map";
+
+.bar {
+  $_color: config.get("bar");
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "some-sass",
 	"displayName": "Some Sass: extended support for SCSS and SassDoc",
 	"description": "Full support for @use and @forward, including aliases, prefixes and hiding. Rich documentation through SassDoc. Workspace-wide code navigation and refactoring.",
-	"version": "2.14.0",
+	"version": "2.14.1",
 	"publisher": "SomewhatStationery",
 	"license": "MIT",
 	"engines": {

--- a/server/src/features/completion/completion.ts
+++ b/server/src/features/completion/completion.ts
@@ -6,12 +6,7 @@ import {
 import type { CompletionItem } from "vscode-languageserver";
 import type { TextDocument } from "vscode-languageserver-textdocument";
 import { useContext } from "../../context-provider";
-import type {
-	IScssDocument,
-	ScssForward,
-	ScssImport,
-	ScssUse,
-} from "../../parser";
+import type { IScssDocument, ScssForward, ScssUse } from "../../parser";
 import { sassBuiltInModules } from "../sass-built-in-modules";
 import type { SassBuiltInModule } from "../sass-built-in-modules";
 import { createCompletionContext } from "./completion-context";
@@ -306,13 +301,10 @@ function traverseTree(
 		accumulator.set(leaf.uri, completionItems);
 
 		// Check to see if we have to go deeper
-		for (const child of leaf.getLinks()) {
-			if (
-				!child.link.target ||
-				(child as ScssImport).dynamic ||
-				(child as ScssImport).css ||
-				child.link.target === scssDocument.uri
-			) {
+		// Don't follow uses, since we start with the document behind the first use, and symbols from further uses aren't available to us
+		// Don't follow imports, since the whole point here is to use the new module system
+		for (const child of leaf.getLinks({ uses: false, imports: false })) {
+			if (!child.link.target || child.link.target === scssDocument.uri) {
 				continue;
 			}
 

--- a/server/src/features/go-definition/go-definition.ts
+++ b/server/src/features/go-definition/go-definition.ts
@@ -9,7 +9,6 @@ import type {
 	INode,
 	IScssDocument,
 	ScssForward,
-	ScssImport,
 	ScssSymbol,
 } from "../../parser";
 import type StorageService from "../../storage";
@@ -262,13 +261,13 @@ function traverseTree(
 	}
 
 	// Check to see if we have to go deeper
-	for (const child of scssDocument.getLinks()) {
-		if (
-			!child.link.target ||
-			(child as ScssImport).dynamic ||
-			(child as ScssImport).css ||
-			child.link.target === scssDocument.uri
-		) {
+	// Don't follow uses, since we start with the document behind the first use, and symbols from further uses aren't available to us
+	// Don't follow imports, since the whole point here is to use the new module system
+	for (const child of scssDocument.getLinks({
+		uses: false,
+		imports: false,
+	})) {
+		if (!child.link.target || child.link.target === scssDocument.uri) {
 			continue;
 		}
 

--- a/server/src/features/hover/hover.ts
+++ b/server/src/features/hover/hover.ts
@@ -262,31 +262,34 @@ export function doHover(document: TextDocument, offset: number): Hover | null {
 		}
 	}
 
-	for (const { reference, exports } of Object.values(sassBuiltInModules)) {
-		for (const [name, { description }] of Object.entries(exports)) {
-			if (name === identifier.name) {
-				// Make sure we're not just hovering over a CSS function.
-				// Confirm we are looking at something that is the child of a module.
-				const isModule =
-					hoverNode.getParent().type === NodeType.Module ||
-					hoverNode.getParent().getParent().type === NodeType.Module;
-				if (isModule) {
-					return {
-						contents: {
-							kind: MarkupKind.Markdown,
-							value: [
-								description,
-								"",
-								`[Sass reference](${reference}#${name})`,
-							].join("\n"),
-						},
-					};
+	if (contents === undefined) {
+		// Look to see if this is a built-in, but only if we have no other content.
+		// Folks may use the same names as built-ins in their modules.
+
+		for (const { reference, exports } of Object.values(sassBuiltInModules)) {
+			for (const [name, { description }] of Object.entries(exports)) {
+				if (name === identifier.name) {
+					// Make sure we're not just hovering over a CSS function.
+					// Confirm we are looking at something that is the child of a module.
+					const isModule =
+						hoverNode.getParent().type === NodeType.Module ||
+						hoverNode.getParent().getParent().type === NodeType.Module;
+					if (isModule) {
+						return {
+							contents: {
+								kind: MarkupKind.Markdown,
+								value: [
+									description,
+									"",
+									`[Sass reference](${reference}#${name})`,
+								].join("\n"),
+							},
+						};
+					}
 				}
 			}
 		}
-	}
 
-	if (contents === undefined) {
 		return null;
 	}
 

--- a/server/src/features/hover/hover.ts
+++ b/server/src/features/hover/hover.ts
@@ -9,7 +9,6 @@ import {
 	ScssVariable,
 	ScssMixin,
 	ScssFunction,
-	ScssImport,
 	ScssForward,
 	tokenizer,
 	Token,
@@ -393,13 +392,13 @@ function traverseTree(
 	}
 
 	// Check to see if we have to go deeper
-	for (const child of scssDocument.getLinks()) {
-		if (
-			!child.link.target ||
-			(child as ScssImport).dynamic ||
-			(child as ScssImport).css ||
-			child.link.target === scssDocument.uri
-		) {
+	// Don't follow uses, since we start with the document behind the first use, and symbols from further uses aren't available to us
+	// Don't follow imports, since the whole point here is to use the new module system
+	for (const child of scssDocument.getLinks({
+		uses: false,
+		imports: false,
+	})) {
+		if (!child.link.target || child.link.target === scssDocument.uri) {
 			continue;
 		}
 

--- a/server/src/features/signature-help/signature-help.ts
+++ b/server/src/features/signature-help/signature-help.ts
@@ -7,7 +7,6 @@ import type {
 	IScssDocument,
 	ScssForward,
 	ScssFunction,
-	ScssImport,
 	ScssMixin,
 } from "../../parser";
 import { applySassDoc } from "../../utils/sassdoc";
@@ -334,13 +333,13 @@ function traverseTree(
 	}
 
 	// Check to see if we have to go deeper
-	for (const child of scssDocument.getLinks()) {
-		if (
-			!child.link.target ||
-			(child as ScssImport).dynamic ||
-			(child as ScssImport).css ||
-			child.link.target === scssDocument.uri
-		) {
+	// Don't follow uses, since we start with the document behind the first use, and symbols from further uses aren't available to us
+	// Don't follow imports, since the whole point here is to use the new module system
+	for (const child of scssDocument.getLinks({
+		uses: false,
+		imports: false,
+	})) {
+		if (!child.link.target || child.link.target === scssDocument.uri) {
 			continue;
 		}
 

--- a/server/src/parser/scss-document.ts
+++ b/server/src/parser/scss-document.ts
@@ -141,15 +141,20 @@ export class ScssDocument implements IScssDocument {
 		return symbols;
 	}
 
-	public getLinks(options = { forwards: true }): ScssLink[] {
+	public getLinks(opts = {}): ScssLink[] {
+		const options = { forwards: true, uses: true, imports: true, ...opts };
 		const links: ScssLink[] = [];
 
-		for (const imp of this.imports.values()) {
-			links.push(imp);
+		if (options.imports) {
+			for (const imp of this.imports.values()) {
+				links.push(imp);
+			}
 		}
 
-		for (const use of this.uses.values()) {
-			links.push(use);
+		if (options.uses) {
+			for (const use of this.uses.values()) {
+				links.push(use);
+			}
 		}
 
 		if (options.forwards) {

--- a/server/src/parser/scss-symbol.ts
+++ b/server/src/parser/scss-symbol.ts
@@ -77,7 +77,11 @@ export interface IScssDocument extends TextDocument, IScssSymbols {
 	fileName: string;
 	/** Find and cache the real path (as opposed to symlinked) */
 	getRealPath: () => Promise<string | null>;
-	getLinks: (options?: { forwards: boolean }) => ScssLink[];
+	getLinks: (options?: {
+		forwards?: boolean;
+		uses?: boolean;
+		imports?: boolean;
+	}) => ScssLink[];
 	getSymbols: () => ScssSymbol[];
 	getNodeAt: (offset: number) => INode | null;
 	getNodeRange: (node: INode) => Range;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -96,7 +96,6 @@ export class SomeSassServer {
 							triggerCharacters: [
 								// For SassDoc annotation completion
 								"@",
-								" ",
 								"/",
 
 								// For @use completion


### PR DESCRIPTION
Suggestions and such should stick to the compiler rules for availability.
Things that are used, and not forwarded, is not available to dependants.

Fixes https://github.com/wkillerud/vscode-scss/issues/61

---

Only return hover info for built-in if there's no other content

Fixes #63 

---

Don't suggest SassDoc annotations on space (very noisy when writing docs).