### PR TITLE
Add missing SassDoc attributes to tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "some-sass",
-	"version": "2.14.0",
+	"version": "2.14.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "some-sass",
-			"version": "2.14.0",
+			"version": "2.14.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "some-sass",
 	"displayName": "Some Sass: extended support for SCSS and SassDoc",
 	"description": "Full support for @use and @forward, including aliases, prefixes and hiding. Rich documentation through SassDoc. Workspace-wide code navigation and refactoring.",
-	"version": "2.14.1",
+	"version": "2.14.2",
 	"publisher": "SomewhatStationery",
 	"license": "MIT",
 	"engines": {

--- a/server/src/test/utils/sassdoc.spec.ts
+++ b/server/src/test/utils/sassdoc.spec.ts
@@ -17,7 +17,38 @@ describe("Utils/SassDoc", () => {
 		strictEqual(applySassDoc(noDoc), "");
 	});
 
-	it("applySassDoc maximal state", () => {
+	it("omits name if identical to symbol name", () => {
+		const allDocs: ScssSymbol = {
+			name: "test",
+			kind: SymbolKind.Method,
+			offset: 0,
+			position: {
+				character: 0,
+				line: 0,
+			},
+			sassdoc: {
+				commentRange: {
+					start: 0,
+					end: 0,
+				},
+				context: {
+					code: "test",
+					line: {
+						start: 0,
+						end: 0,
+					},
+					type: "mixin",
+					name: "test",
+					scope: "global",
+				},
+				description: "This is a description",
+				name: "test",
+			},
+		};
+		strictEqual(applySassDoc(allDocs), `This is a description`);
+	});
+
+	it("omits access if public, even if defined", () => {
 		const allDocs: ScssSymbol = {
 			name: "test",
 			kind: SymbolKind.Method,
@@ -43,6 +74,37 @@ describe("Utils/SassDoc", () => {
 				},
 				description: "This is a description",
 				access: "public",
+			},
+		};
+		strictEqual(applySassDoc(allDocs), `This is a description`);
+	});
+
+	it("applySassDoc maximal state", () => {
+		const allDocs: ScssSymbol = {
+			name: "test",
+			kind: SymbolKind.Method,
+			offset: 0,
+			position: {
+				character: 0,
+				line: 0,
+			},
+			sassdoc: {
+				commentRange: {
+					start: 0,
+					end: 0,
+				},
+				context: {
+					code: "test",
+					line: {
+						start: 0,
+						end: 0,
+					},
+					type: "mixin",
+					name: "test",
+					scope: "global",
+				},
+				description: "This is a description",
+				access: "private",
 				alias: "alias",
 				aliased: ["test", "other-test"],
 				author: ["Johnny Appleseed", "Foo Bar"],
@@ -155,10 +217,6 @@ describe("Utils/SassDoc", () => {
 
 @param string\`parameter\` [yes] - helpful description
 
-@access public
-
-@group mixins, helpers
-
 @type color,string
 
 @prop {number}\`foo/bar\` [yes] - what
@@ -190,6 +248,10 @@ describe("Utils/SassDoc", () => {
 \`\`\`scss
 @include test;
 \`\`\`
+
+@access private
+
+@group mixins, helpers
 
 @todo nothing`,
 		);

--- a/server/src/test/utils/sassdoc.spec.ts
+++ b/server/src/test/utils/sassdoc.spec.ts
@@ -1,0 +1,197 @@
+import { strictEqual } from "assert";
+import { SymbolKind } from "vscode-languageserver-types";
+import { ScssSymbol } from "../../parser";
+import { applySassDoc } from "../../utils/sassdoc";
+
+describe("Utils/SassDoc", () => {
+	it("applySassDoc empty state", () => {
+		const noDoc: ScssSymbol = {
+			name: "test",
+			kind: SymbolKind.Property,
+			offset: 0,
+			position: {
+				character: 0,
+				line: 0,
+			},
+		};
+		strictEqual(applySassDoc(noDoc), "");
+	});
+
+	it("applySassDoc maximal state", () => {
+		const allDocs: ScssSymbol = {
+			name: "test",
+			kind: SymbolKind.Method,
+			offset: 0,
+			position: {
+				character: 0,
+				line: 0,
+			},
+			sassdoc: {
+				commentRange: {
+					start: 0,
+					end: 0,
+				},
+				context: {
+					code: "test",
+					line: {
+						start: 0,
+						end: 0,
+					},
+					type: "mixin",
+					name: "test",
+					scope: "global",
+				},
+				description: "This is a description",
+				access: "public",
+				alias: "alias",
+				aliased: ["test", "other-test"],
+				author: ["Johnny Appleseed", "Foo Bar"],
+				content: "Overrides for test defaults",
+				deprecated: "No, but yes for testing",
+				example: [
+					{
+						code: "@include test;",
+						description: "Very helpful example",
+						type: "scss",
+					},
+				],
+				group: ["mixins", "helpers"],
+				ignore: ["this", "that"],
+				link: [
+					{
+						url: "http://localhost:8080",
+						caption: "listen!",
+					},
+				],
+				name: "Test name",
+				output: "Things",
+				parameter: [
+					{
+						name: "parameter",
+						default: "yes",
+						description: "helpful description",
+						type: "string",
+					},
+				],
+				property: [
+					{
+						path: "foo/bar",
+						default: "yes",
+						description: "what",
+						name: "no",
+						type: "number",
+					},
+				],
+				require: [
+					{
+						name: "other-test",
+						type: "string",
+						autofill: true,
+						description: "helpful description",
+						external: true,
+						url: "http://localhost:1337",
+					},
+				],
+				return: { type: "string", description: "helpful result" },
+				see: [
+					{
+						name: "other-thing",
+						commentRange: {
+							start: 0,
+							end: 0,
+						},
+						context: {
+							code: "test",
+							line: {
+								start: 0,
+								end: 0,
+							},
+							type: "mixin",
+							name: "test",
+							scope: "global",
+						},
+						description: "This is a description",
+					},
+				],
+				since: [
+					{
+						version: "0.0.1",
+						description: "The beginning of time",
+					},
+				],
+				throws: ["a fit"],
+				todo: ["nothing"],
+				type: ["color", "string"],
+				usedBy: [
+					{
+						name: "other-thing",
+						commentRange: {
+							start: 0,
+							end: 0,
+						},
+						context: {
+							code: "test",
+							line: {
+								start: 0,
+								end: 0,
+							},
+							type: "mixin",
+							name: "test",
+							scope: "global",
+						},
+						description: "This is a description",
+					},
+				],
+			},
+		};
+
+		strictEqual(
+			applySassDoc(allDocs),
+			`This is a description
+
+@deprecated No, but yes for testing
+
+@name Test name
+
+@param string\`parameter\` [yes] - helpful description
+
+@access public
+
+@group mixins, helpers
+
+@type color,string
+
+@prop {number}\`foo/bar\` [yes] - what
+
+@content Overrides for test defaults
+
+@output Things
+
+@return string - helpful result
+
+@throw a fit
+
+@require {string}\`other-test\` - helpful description http://localhost:1337
+
+@alias \`alias\`
+
+@see \`other-thing\`
+
+@since 0.0.1 - The beginning of time
+
+@author Johnny Appleseed
+
+@author Foo Bar
+
+[listen!](http://localhost:8080)
+
+@example Very helpful example
+
+\`\`\`scss
+@include test;
+\`\`\`
+
+@todo nothing`,
+		);
+	});
+});

--- a/server/src/utils/sassdoc.ts
+++ b/server/src/utils/sassdoc.ts
@@ -17,7 +17,7 @@ export function applySassDoc(symbol: ScssSymbol): string {
 		description += `\n\n@deprecated ${doc.deprecated}`;
 	}
 
-	if (doc.name) {
+	if (doc.name && doc.name !== symbol.name) {
 		description += `\n\n@name ${doc.name}`;
 	}
 
@@ -40,14 +40,6 @@ export function applySassDoc(symbol: ScssSymbol): string {
 				description += ` - ${parameter.description}`;
 			}
 		}
-	}
-
-	if (doc.access) {
-		description += `\n\n@access ${doc.access}`;
-	}
-
-	if (doc.group && doc.group.length > 0) {
-		description += `\n\n@group ${doc.group.join(", ")}`;
 	}
 
 	// Type is for standalone variable annotation
@@ -167,6 +159,15 @@ export function applySassDoc(symbol: ScssSymbol): string {
 
 			description += ["\n", "```scss", example.code, "```"].join("\n");
 		}
+	}
+
+	if (doc.access === "private") {
+		description += `\n\n@access private`;
+	}
+
+	const groups = doc.group?.filter((g) => g !== "undefined");
+	if (groups && groups.length > 0) {
+		description += `\n\n@group ${groups.join(", ")}`;
 	}
 
 	if (doc.todo) {

--- a/server/src/utils/sassdoc.ts
+++ b/server/src/utils/sassdoc.ts
@@ -17,6 +17,10 @@ export function applySassDoc(symbol: ScssSymbol): string {
 		description += `\n\n@deprecated ${doc.deprecated}`;
 	}
 
+	if (doc.name) {
+		description += `\n\n@name ${doc.name}`;
+	}
+
 	// Function and mixin parameters, listed one per line like JSDoc
 	if (doc.parameter) {
 		for (const parameter of doc.parameter) {
@@ -36,6 +40,14 @@ export function applySassDoc(symbol: ScssSymbol): string {
 				description += ` - ${parameter.description}`;
 			}
 		}
+	}
+
+	if (doc.access) {
+		description += `\n\n@access ${doc.access}`;
+	}
+
+	if (doc.group && doc.group.length > 0) {
+		description += `\n\n@group ${doc.group.join(", ")}`;
 	}
 
 	// Type is for standalone variable annotation
@@ -155,6 +167,10 @@ export function applySassDoc(symbol: ScssSymbol): string {
 
 			description += ["\n", "```scss", example.code, "```"].join("\n");
 		}
+	}
+
+	if (doc.todo) {
+		description += `\n\n@todo ${doc.todo}`;
 	}
 
 	return description;


### PR DESCRIPTION
Adds:

- name, if different from the actual name
- group
- access, but only if private (the value is public by default)
- todo